### PR TITLE
Fixes #29 - handle() does not exist in Laravel 5.5

### DIFF
--- a/src/Command/GenerateModelCommand.php
+++ b/src/Command/GenerateModelCommand.php
@@ -47,7 +47,7 @@ class GenerateModelCommand extends Command
     /**
      * Executes the command
      */
-    public function fire()
+    public function handle()
     {
         $config = $this->createConfig();
 


### PR DESCRIPTION
Laravel 5.5 has changed fire() to handle() in Commands. 
To get it working again we just need to change the function name.