### PR TITLE
Change autoincrementProperty access level to public

### DIFF
--- a/src/Processor/CustomPrimaryKeyProcessor.php
+++ b/src/Processor/CustomPrimaryKeyProcessor.php
@@ -75,7 +75,7 @@ class CustomPrimaryKeyProcessor implements ProcessorInterface
             $model->addProperty($keyTypeProperty);
         }
         if ($column->getAutoincrement() !== true) {
-            $autoincrementProperty = new PropertyModel('incrementing', 'protected', false);
+            $autoincrementProperty = new PropertyModel('incrementing', 'public', false);
             $autoincrementProperty->setDocBlock(
                 new DocBlockModel('Indicates if the IDs are auto-incrementing.', '', '@var bool')
             );


### PR DESCRIPTION
[Docs](https://laravel.com/docs/master/eloquent#defining-models) / Primary Keys

"If you wish to use a non-incrementing or a non-numeric primary key you must set the **public** $incrementing property on your model to false"

If it's not public, you get "FatalErrorException Access level to App\TestModel::$incrementing must be public (as in class Illuminate\Database\Eloquent\Model)"