### PR TITLE
Namespace of new model based on output_path

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -26,6 +26,8 @@ class Config
             $inputConfig = $this->merge($inputConfig, $appConfig);
         }
 
+        if(!isset($inputConfig['namespace']) && isset($inputConfig["output_path"])) $inputConfig['namespace'] = "App\\" . str_replace(DIRECTORY_SEPARATOR,"\\",substr($inputConfig["output_path"],0,-1));
+
         $this->config = $this->merge($inputConfig, $this->getBaseConfig());
     }
 


### PR DESCRIPTION
Normally this is used without specifying the Namespace, therefore I added a line in Config.php to set the namespace of the new Model based on the output_path if name space is not specified