### PR TITLE
Add a new feature to create all database models at once / Add database schema support

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -14,6 +14,16 @@ class Config
     protected $config;
 
     /**
+     * @var string
+     */
+    protected $defaultSchemaName;
+
+    /**
+     * @var string
+     */
+    protected $schemaName;
+
+    /**
      * Config constructor.
      * @param array $inputConfig
      * @param array|null $appConfig
@@ -29,6 +39,30 @@ class Config
         $this->config = $this->merge($inputConfig, $this->getBaseConfig());
     }
 
+    public function getSchemaNameForQuery()
+    {
+        $schemaName = $this->getSchemaName();
+        //Cannot add the default schema name set in the connection for query
+        if ($schemaName === $this->defaultSchemaName) {
+            $schemaName = "";
+        }
+        if($schemaName !== ""){
+            $schemaName .= ".";
+        }
+        return $schemaName;
+    }
+
+    public function getSchemaName()
+    {
+        $schemaName = "";
+        if (isset($this->schemaName) && $this->schemaName !== "") {
+            $schemaName = $this->schemaName;
+        } elseif (isset($this->defaultSchemaName) && $this->defaultSchemaName !== "") {
+            $schemaName = $this->defaultSchemaName;
+        }
+        return $schemaName;
+    }
+
     /**
      * @param string     $key
      * @param mixed|null $default
@@ -40,12 +74,39 @@ class Config
     }
 
     /**
+     * @param string     $key
+     * @param mixed      $value
+     */
+    public function set($key, $value)
+    {
+        $this->config[$key] = $value;
+    }
+
+
+
+    /**
      * @param string $key
      * @return bool
      */
     public function has($key)
     {
         return isset($this->config[$key]);
+    }
+
+    /**
+     * @param string      $schemaName
+     */
+    public function setSchemaName(string $schemaName)
+    {
+        $this->schemaName = $schemaName;
+    }
+
+   /**
+     * @param string      $defaultSchemaName
+     */
+    public function setDefaultSchemaName(string $defaultSchemaName)
+    {
+        $this->defaultSchemaName = $defaultSchemaName;
     }
 
     /**

--- a/src/Processor/CustomPrimaryKeyProcessor.php
+++ b/src/Processor/CustomPrimaryKeyProcessor.php
@@ -43,8 +43,7 @@ class CustomPrimaryKeyProcessor implements ProcessorInterface
     {
         $schemaManager = $this->databaseManager->connection($config->get('connection'))->getDoctrineSchemaManager();
         $prefix        = $this->databaseManager->connection($config->get('connection'))->getTablePrefix();
-
-        $tableDetails = $schemaManager->listTableDetails($prefix . $model->getTableName());
+        $tableDetails = $schemaManager->listTableDetails($config->getSchemaNameForQuery() . $prefix . $model->getTableName());
         $primaryKey = $tableDetails->getPrimaryKey();
         if ($primaryKey === null) {
             return;

--- a/src/Processor/ExistenceCheckerProcessor.php
+++ b/src/Processor/ExistenceCheckerProcessor.php
@@ -35,8 +35,8 @@ class ExistenceCheckerProcessor implements ProcessorInterface
         $schemaManager = $this->databaseManager->connection($config->get('connection'))->getDoctrineSchemaManager();
         $prefix = $this->databaseManager->connection($config->get('connection'))->getTablePrefix();
 
-        if (!$schemaManager->tablesExist($prefix . $model->getTableName())) {
-            throw new GeneratorException(sprintf('Table %s does not exist', $prefix . $model->getTableName()));
+        if (!$schemaManager->tablesExist($config->getSchemaNameForQuery() . $prefix . $model->getTableName())) {
+            throw new GeneratorException(sprintf('Table %s does not exist', $config->getSchemaNameForQuery() . $prefix . $model->getTableName()));
         }
     }
 

--- a/src/Processor/FieldProcessor.php
+++ b/src/Processor/FieldProcessor.php
@@ -45,7 +45,7 @@ class FieldProcessor implements ProcessorInterface
         $schemaManager = $this->databaseManager->connection($config->get('connection'))->getDoctrineSchemaManager();
         $prefix        = $this->databaseManager->connection($config->get('connection'))->getTablePrefix();
 
-        $tableDetails       = $schemaManager->listTableDetails($prefix . $model->getTableName());
+        $tableDetails       = $schemaManager->listTableDetails($config->getSchemaNameForQuery() . $prefix . $model->getTableName());
         $primaryColumnNames = $tableDetails->getPrimaryKey() ? $tableDetails->getPrimaryKey()->getColumns() : [];
 
         $columnNames = [];

--- a/src/Processor/TableNameProcessor.php
+++ b/src/Processor/TableNameProcessor.php
@@ -42,9 +42,9 @@ class TableNameProcessor implements ProcessorInterface
         $model->setName(new ClassNameModel($className, $this->helper->getShortClassName($baseClassName)));
         $model->addUses(new UseClassModel(ltrim($baseClassName, '\\')));
         $model->setTableName($tableName ?: $this->helper->getDefaultTableName($className));
-
-        if ($model->getTableName() !== $this->helper->getDefaultTableName($className)) {
-            $property = new PropertyModel('table', 'protected', $model->getTableName());
+        
+        if ($model->getTableName() !== $this->helper->getDefaultTableName($className) || $config->get('force_table_name')) {
+            $property = new PropertyModel('table', 'protected', $config->getSchemaName().".".$model->getTableName());
             $property->setDocBlock(new DocBlockModel('The table associated with the model.', '', '@var string'));
             $model->addProperty($property);
         }


### PR DESCRIPTION
**Add a new feature to create all database models at once**

Change the command argument "class-name" from required to optionnal
When you do not specify a class-name, it will generate a model for every table of the database (except for the many-to-many tables, who should not have a model anyway)

**Add database schema support**

- add a new option to specify the schema you generate models from (only used when you do not specify a class-name)
- add a new option to force table name property on model to be set even for tables in the default database schema (usefull for multiple schema database who use only one connection)

**Change in the many to many relationship generation**

Generate a many to many relationship in model even for tables that have more than 2 columns (pivot). More code could be added to automaticaly generate the pivot.  