### PR TITLE
Bugfix for singular table names.

### DIFF
--- a/src/Command/GenerateModelsCommand.php
+++ b/src/Command/GenerateModelsCommand.php
@@ -36,6 +36,7 @@ class GenerateModelsCommand extends Command
             }
 
             $config->setClassName(EmgHelper::getClassNameByTableName($tableName));
+            $config->setTableName($tableName);
             $model = $this->generator->generateModel($config);
             $this->saveModel($model);
 


### PR DESCRIPTION
I've got an error in TableNameProcessor.php line 29: `Table telescope_monitorings does not exist`, 
because some of tables are stored with singular names, eg. _telescope_monitoring_ and not _telescope_monitorings_.
Because **krlove:generate:models** gets all table names directly from database schema, you can ad table name directly to the config.
