### PR TITLE
allow to replace every processor with a custom one

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ return [
     'connection' => null,
     'no_backup' => null,
     'db_types' => null,
+    'processors'      => [
+        '\Krlove\EloquentModelGenerator\Processor\FieldProcessor',
+        '\Krlove\EloquentModelGenerator\Processor\NamespaceProcessor',
+        '\Krlove\EloquentModelGenerator\Processor\RelationProcessor',
+        '\Krlove\EloquentModelGenerator\Processor\CustomPropertyProcessor',
+        '\Krlove\EloquentModelGenerator\Processor\TableNameProcessor',
+        '\Krlove\EloquentModelGenerator\Processor\CustomPrimaryKeyProcessor',
+    ],
 ];
 ```
 

--- a/src/Provider/GeneratorServiceProvider.php
+++ b/src/Provider/GeneratorServiceProvider.php
@@ -31,14 +31,13 @@ class GeneratorServiceProvider extends ServiceProvider
         $this->app->singleton(TypeRegistry::class);
         $this->app->singleton(GenerateCommandEventListener::class);
 
-        $this->app->tag([
-            FieldProcessor::class,
-            NamespaceProcessor::class,
-            RelationProcessor::class,
-            CustomPropertyProcessor::class,
-            TableNameProcessor::class,
-            CustomPrimaryKeyProcessor::class,
-        ], self::PROCESSOR_TAG);
+        if (config('eloquent_model_generator.processors')) {
+            $generators = config('eloquent_model_generator.processors');
+        } else {
+            throw new \RuntimeException('No processors configured');
+        }
+
+        $this->app->tag($generators, self::PROCESSOR_TAG);
 
         $this->app->bind(Generator::class, function ($app) {
             return new Generator($app->tagged(self::PROCESSOR_TAG));


### PR DESCRIPTION
hi,

i am also not a big fan of this "plural thing". 
the user should decide how table or class names should be named.
because this class allows the creation of all models at once, the parameter "--table-name" is not usable at this point.
another example: if someone doesn´t want specific columns in `$fillable = [....]` I now have full control over this
because I can replace the "FieldProcessor" with my own one and create everything the way I like.

i would be happy to see a merge here because I believe this little change gives 100% freedom to every user
that has a problem with the default way, things get created.

thanks,
micha